### PR TITLE
queries is not mendatory for collection+json

### DIFF
--- a/lib/roar/representer/json/collection_json.rb
+++ b/lib/roar/representer/json/collection_json.rb
@@ -23,7 +23,8 @@ module Roar::Representer::JSON
 
         collection :queries, :extend => Roar::Representer::JSON::HyperlinkRepresenter
         def queries
-          compile_links_for(representable_attrs.collection_representers[:queries].link_configs)
+          queries_representers = representable_attrs.collection_representers[:queries]
+          compile_links_for(queries_representers.link_configs) unless queries_representers.nil?
         end
         def queries=(v)
         end


### PR DESCRIPTION
regarding the [collection+json spec](http://amundsen.com/media-types/collection/format/#reading-items), queries is not mendatory: 
"Note that the valid response is actually a complete collection document that contains only one item (and possibly related queries and template properties)."