### PR TITLE
[PK] Fix README to use the new require 'roar/coercion' syntax

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -241,7 +241,7 @@ We're currently [working on](https://github.com/apotonick/roar/issues/85) better
 Roar provides coercion with the [virtus](https://github.com/solnic/virtus) gem.
 
 ```ruby
-require 'roar/feature/coercion'
+require 'roar/coercion'
 
 module SongRepresenter
   include Roar::JSON


### PR DESCRIPTION
The old syntax/file structure is no longer available, resulting in a LoadError.