### PR TITLE
Fix reference to JSONAPI in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -433,7 +433,7 @@ A minimal representation can be defined as follows.
 require 'roar/json/json_api'
 
 module SongsRepresenter
-  include Roar::JSON::JsonApi
+  include Roar::JSON::JSONAPI
   type :songs
 
   property :id


### PR DESCRIPTION
Updates the README content to reference `Roar::JSON::JSONAPI` instead of `...::JsonApi`, now that it's been renamed.