### PR TITLE
Fix JSONAPI Decorator collection serialization

### DIFF
--- a/lib/roar/json/json_api.rb
+++ b/lib/roar/json/json_api.rb
@@ -22,7 +22,7 @@ module Roar
           singular = self # e.g. Song::Representer
 
           # this basically does Module.new { include Hash::Collection .. }
-          build_inline(nil, [Document::Collection, Representable::Hash::Collection, Roar::JSON], "", {}) do
+          build_inline(nil, [Representable::Hash::Collection, Document::Collection, Roar::JSON], "", {}) do
             items extend: singular, :parse_strategy => :sync
 
             representable_attrs[:resource_representer] = singular.representable_attrs[:resource_representer]

--- a/test/json_api_test.rb
+++ b/test/json_api_test.rb
@@ -193,8 +193,8 @@ class JSONAPITest < MiniTest::Spec
 
   # collection with links
   [Singular, SingularDecorator].each do |representer|
-    describe "collection with links and compound" do
-      subject { Singular.for_collection.prepare([song, song]) }
+    describe "collection with links and compound with #{representer}" do
+      subject { representer.for_collection.prepare([song, song]) }
 
       let (:document) do
         {


### PR DESCRIPTION
When using the Decorator-style, JSONAPI representations for collections are returning an array of individually serialized resources. I've made a small change in json_api_test to enable a test that I think was meant to cover this behavior. The bugfix itself was just a matter of re-ordering the mixins used by `for_collection`.

Before:

~~~ruby
Widget = Struct.new(:id)

class WidgetDecorator < Roar::Decorator
  include Roar::JSON::JSONAPI
  type :widgets
  property :id
end

widgets = [Widget.new(1), Widget.new(2)]
WidgetDecorator.for_collection.prepare(widgets).to_hash
# => [{"widgets"=>{"id"=>1}}, {"widgets"=>{"id"=>2}}]
~~~

After:

~~~ruby
WidgetDecorator.for_collection.prepare(widgets).to_hash
# => {"widgets"=>[{"id"=>1}, {"id"=>2}]}
~~~