### PR TITLE
Fix JSONAPI to_hash(options: 'here')

### DIFF
--- a/lib/roar/json/json_api.rb
+++ b/lib/roar/json/json_api.rb
@@ -36,7 +36,7 @@ module Roar
       module Singular
         def to_hash(options={})
           # per resource:
-          super(:exclude => [:links]).tap do |hash|
+          super(options.merge(:exclude => [:links])).tap do |hash|
             hash["links"] = hash.delete("_links") if hash["_links"]
           end
         end

--- a/test/json_api_test.rb
+++ b/test/json_api_test.rb
@@ -42,14 +42,12 @@ class JSONAPITest < MiniTest::Spec
     end
   end
 
-
-
   module Singular
     include Roar::JSON::JSONAPI
     type :songs
 
     property :id
-    property :title
+    property :title, if: lambda { |args| args[:omit_title] != true }
 
     # local per-model "id" links
     links do
@@ -84,7 +82,7 @@ class JSONAPITest < MiniTest::Spec
     type :songs
 
     property :id
-    property :title
+    property :title, if: lambda { |args| args[:omit_title] != true }
 
     # local per-model "id" links
     links do
@@ -148,6 +146,11 @@ class JSONAPITest < MiniTest::Spec
       # to_hash
       it do
         subject.to_hash.must_equal document
+      end
+
+      # to_hash(options)
+      it do
+        subject.to_hash(omit_title: true)['songs'].wont_include('title')
       end
 
       # #to_json
@@ -235,6 +238,13 @@ class JSONAPITest < MiniTest::Spec
       # to_hash
       it do
         subject.to_hash.must_equal document
+      end
+
+      # to_hash(options)
+      it do
+        subject.to_hash(omit_title: true)['songs'].each do |song|
+          song.wont_include('title')
+        end
       end
 
       # #to_json
@@ -334,7 +344,6 @@ class JSONAPITest < MiniTest::Spec
       )
     end
   end
-
 
   class ExplicitMeta < self
     module Representer


### PR DESCRIPTION
The options passed to `to_hash` were being discarded in the path through JSONAPI::Singular#to_hash.

Before:

~~~ruby
module WidgetRepresenter
  include Roar::JSON::JSONAPI
  type :widgets
  property :id, getter: -> opts { opts[:multiplier].to_i * id }
end

widgets.extend(WidgetRepresenter.for_collection).to_hash(
  multiplier: 10
) # => {"widgets"=>[{"id"=>0}, {"id"=>0}]}

widgets.first.extend(WidgetRepresenter).to_hash(
  multiplier: 50
) # => {"widgets"=>{"id"=>0}}
~~~

After:

~~~ruby
widgets.extend(WidgetRepresenter.for_collection).to_hash(
  multiplier: 10
) # => {"widgets"=>[{"id"=>10}, {"id"=>20}]}

widgets.first.extend(WidgetRepresenter).to_hash(
  multiplier: 50
) # => {"widgets"=>{"id"=>50}}
~~~