### PR TITLE
add spec for client-side decorator pattern

### DIFF
--- a/lib/roar/client.rb
+++ b/lib/roar/client.rb
@@ -1,10 +1,12 @@
 require "roar/http_verbs"
 
 module Roar
-  # Automatically add accessors for properties and collections. Also mixes in HttpVerbs.
+
+  # Mix in HttpVerbs. 
   module Client
     include HttpVerbs
 
+    # Add accessors for properties and collections to modules.
     def self.extended(base)
       base.instance_eval do
         representable_attrs.each do |attr|

--- a/test/decorator_client_test.rb
+++ b/test/decorator_client_test.rb
@@ -1,0 +1,64 @@
+require 'test_helper'
+require 'roar/decorator'
+require 'roar/client'
+
+class DecoratorClientTest < MiniTest::Spec
+  class Crew
+    attr_accessor :moniker, :company
+  end
+  
+  class CrewDecorator < Roar::Decorator
+    include Roar::JSON
+    include Roar::Hypermedia
+
+    property :moniker, as: :name
+    property :company, as: :label
+
+    link(:self) do
+      "http://bands/#{represented.moniker}"
+    end
+  end
+
+  class CrewClient < CrewDecorator
+    include Roar::Client
+  end
+
+  before do
+    @crew = Crew.new
+    @client = CrewClient.new(@crew)
+  end    
+
+  describe 'HttpVerbs integration' do
+    describe '#get' do
+      it 'updates instance with incoming representation' do
+        @client.get(uri: 'http://localhost:4567/bands/slayer', as: 'application/json')
+        @crew.moniker.must_equal 'Slayer'
+        @crew.company.must_equal 'Canadian Maple'
+      end
+    end
+
+    describe '#post' do
+      it 'creates a new resource with the given values' do
+        @crew.moniker = 'Strung Out'
+        @crew.company.must_be_nil
+
+        @client.post(uri: 'http://localhost:4567/bands', as: 'application/xml')
+        @crew.moniker.must_equal 'STRUNG OUT'
+        @crew.company.must_be_nil
+      end
+    end
+  end
+
+  describe '#to_hash' do
+    it 'suppresses rendering links' do
+      @crew.moniker = 'Silence'
+      @client.to_json.must_equal %{{\"name\":\"Silence\",\"links\":[]}}
+    end
+    
+    # since this is considered dangerous, we test the mutuable options.
+    it "adds links: false to options" do
+      @client.to_hash(options = {})
+      options.must_equal({:links => false})
+    end
+  end
+end


### PR DESCRIPTION
Spec for client-side decorator syntax I presented in https://github.com/apotonick/roar/issues/94

I put the spec in a separate file from the client-side module spec because the usage pattern is rather different. (The pattern is quite lovely, in fact.)

I also updated the comments in lib/roar/client.rb to clarify that the accessors are not automatically added by including the module, but rather via self.extended(base), which is not used in the decorator pattern.

I didn't do all the HttpVerbs as they are already tested in their own test and it felt as if get and post were enough to document and protect the integration. Let me know if you want me to add tests for the full set.