### PR TITLE
update gemspec (and Gemfile, doh!) for v1.0.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "http://rubygems.org"
 gemspec
 
 # gem "representable", "~> 2.1.0"
-gem "representable", :path => "../representable"
+# gem "representable", :path => "../representable"
 
 # as long as this is not merged, i'll vendor the runner file.
 # gem "sinatra-contrib", :git => "git@github.com:apotonick/sinatra-contrib.git", :branch => "runner"

--- a/roar.gemspec
+++ b/roar.gemspec
@@ -17,11 +17,11 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency "representable", ">= 2.0.1", "<= 3.0.0"
+  s.add_runtime_dependency "representable", ">= 2.1.5", "<= 3.0.0"
 
   s.add_development_dependency "rake", ">= 0.10.1"
   s.add_development_dependency "test_xml", "0.1.6"
-  s.add_development_dependency "minitest",	">= 5.4.2"
+  s.add_development_dependency "minitest", ">= 5.4.2"
   s.add_development_dependency "sinatra"
   s.add_development_dependency "sinatra-contrib"
   s.add_development_dependency "virtus", ">= 1.0.0"


### PR DESCRIPTION
json_api_test fails with

    /home/vagrant/.gem/ruby/2.1.5/gems/representable-2.1.4/lib/representable/config.rb:32:in `add': undefined method `merge!' for nil:NilClass (NoMethodError)

under representable-2.1.4, but passes under representable-2.1.5.