### PR TITLE
Ensure that test servers are killed in event of failure due to exception

### DIFF
--- a/test/integration/runner.rb
+++ b/test/integration/runner.rb
@@ -30,13 +30,20 @@ class SslServerRunner < ServerRunner
   end
 end
 
-runner = ServerRunner.new
-runner.run
+begin
+  runner = ServerRunner.new
+  runner.run
 
-ssl_runner = SslServerRunner.new
-ssl_runner.run
+  ssl_runner = SslServerRunner.new
+  ssl_runner.run
 
-Minitest.after_run do
+  Minitest.after_run do
+    runner.kill
+    ssl_runner.kill
+  end
+rescue Exception => e
   runner.kill
   ssl_runner.kill
+
+  raise e
 end


### PR DESCRIPTION
I've been trying to run the tests, but the SslServerRunner keeps throwing an exception (separate issue I'm still investigating).  However, when that happens the rake task dies but the server processes are still running in the background listening in on ports 8443 and 4567.  This ensures that, should that happen, those processes are still killed before the rake task exits.