### PR TITLE
JSONAPI: Allow collections within compounds to use extend option

### DIFF
--- a/lib/roar/json/json_api.rb
+++ b/lib/roar/json/json_api.rb
@@ -14,6 +14,11 @@ module Roar
           extend ForCollection
 
           representable_attrs[:resource_representer] = Class.new(Resource::Representer)
+
+          private
+            def create_representation_with(doc, options, format)
+              super(doc, options.merge(:only_body => true), format)
+            end
         end
       end
 


### PR DESCRIPTION
@apotonick @pd  
Fixes https://github.com/apotonick/roar/pull/127 

How it is now with the current implementation:
```ruby
{
  "albums"=> {"id"=>1}, 
  "linked"=> {
    "songs"=> [
      {"songs"=>{"id"=>1, "title"=>"Stand Up"}}, 
      {"songs"=>{"id"=>2, "title"=>"Audition Mantra"}}
    ]
  }
}
```

How it is after this fix:
```ruby
{
  'albums' => { 'id' => 1 },
  'linked' => {
    'songs' => [
      {'id' => 1, 'title' => 'Stand Up'},
      {'id' => 2, 'title' => 'Audition Mantra'}
    ]
  }
}
```

This fix removes the second, redundant `songs` wrap by writing fragments to the doc without the extra wrap.