### PR TITLE
Update namespace changes in docs

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -14,7 +14,7 @@
 
 ## Added
 
-* `Roar::JSON::JsonApi` supports JSON-API. A big thanks to @oliverbarnes for his continous help, support and research on how to implement this standard.
+* `Roar::JSON::JSONAPI` supports JSON-API. A big thanks to @oliverbarnes for his continous help, support and research on how to implement this standard.
 
 
 ## Relevant

--- a/README.markdown
+++ b/README.markdown
@@ -375,7 +375,7 @@ module SongRepresenter
 end
 ```
 
-Documentation for HAL can be found in the [API docs](http://rdoc.info/github/apotonick/roar/Roar/Representer/JSON/HAL).
+Documentation for HAL can be found in the [API docs](http://rdoc.info/github/apotonick/roar/Roar/JSON/HAL).
 
 Make sure you [understand the different contexts](#hypermedia) for links when using decorators.
 
@@ -418,7 +418,7 @@ album.to_json
 
 HAL keys nested resources under the `_embedded` key and then by their type.
 
-All HAL features in Roar are discussed in the [API docs](http://rdoc.info/github/apotonick/roar/Roar/Representer/JSON/HAL), including [array links](https://github.com/apotonick/roar/blob/master/lib/roar/json/hal.rb#L176).
+All HAL features in Roar are discussed in the [API docs](http://rdoc.info/github/apotonick/roar/Roar/JSON/HAL), including [array links](https://github.com/apotonick/roar/blob/master/lib/roar/json/hal.rb#L196).
 
 
 ## JSON-API
@@ -713,8 +713,8 @@ Roar also comes with XML support.
 
 ```ruby
 module SongRepresenter
-  include Roar::Representer::XML
-  include Roar::Representer::Hypermedia
+  include Roar::XML
+  include Roar::Hypermedia
 
   property :title
   property :id
@@ -725,7 +725,7 @@ module SongRepresenter
 end
 ```
 
-Include the `Roar::Representer::XML` engine and get bi-directional XML for your objects.
+Include the `Roar::XML` engine and get bi-directional XML for your objects.
 
 ```ruby
 song = Song.new(title: "Roxanne", id: 42)

--- a/lib/roar/coercion.rb
+++ b/lib/roar/coercion.rb
@@ -5,8 +5,8 @@ require 'representable/coercion'
 module Roar
   # Use the +:type+ option to specify the conversion type.
   # class ImmigrantSong
-  #   include Roar::Representer::JSON
-  #   include Roar::Representer::Feature::Coercion
+  #   include Roar::JSON
+  #   include Roar::Coercion
   #
   #   property :composed_at, :type => DateTime, :default => "May 12th, 2012"
   # end

--- a/lib/roar/hypermedia.rb
+++ b/lib/roar/hypermedia.rb
@@ -4,7 +4,7 @@ module Roar
   # Example:
   #
   #   class Order
-  #     include Roar::Representer::JSON
+  #     include Roar:JSON
   #
   #     property :id
   #

--- a/lib/roar/json/hal.rb
+++ b/lib/roar/json/hal.rb
@@ -16,7 +16,7 @@ module Roar
     # Example:
     #
     #   module OrderRepresenter
-    #     include Roar::Representer::JSON::HAL
+    #     include Roar::JSON::HAL
     #
     #     property :id
     #     collection :items, :class => Item, :extend => ItemRepresenter, :embedded => true
@@ -93,8 +93,8 @@ module Roar
       # following the HAL specification: http://stateless.co/hal_specification.html
       #
       #   module SongRepresenter
-      #     include Roar::Representer::JSON
-      #     include Roar::Representer::JSON::HAL::Links
+      #     include Roar::JSON
+      #     include Roar::JSON::HAL::Links
       #
       #     link :self { "http://self" }
       #   end


### PR DESCRIPTION
This updates the docs and comments to the namspace changes introduced in commit 9c42e95b3229c4ec348d191c1a8629e31fdda657: "Removed `Representer` and `Feature` namespace."