### PR TITLE
Update the documentation with required dependencies which were removed from representable gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,5 @@ source "http://rubygems.org"
 # Specify your gem's dependencies in roar.gemspec
 gemspec
 
-# gem "representable", "~> 2.1.0"
-gem "representable", :path => "../representable"
-
 # as long as this is not merged, i'll vendor the runner file.
 # gem "sinatra-contrib", :git => "git@github.com:apotonick/sinatra-contrib.git", :branch => "runner"

--- a/README.markdown
+++ b/README.markdown
@@ -24,6 +24,30 @@ Roar is just a thin layer on top of the [representable](https://github.com/apoto
 
 If in need for a feature, make sure to check the [representable API docs](https://github.com/apotonick/representable) first.
 
+## Installation
+
+The roar gem runs with all Ruby versions >= 1.9.3.
+
+```ruby
+gem 'roar'
+```
+
+### Dependencies
+
+Roar does not bundle dependencies for JSON and XML.
+
+If you want to use JSON, add the following to your Gemfile:
+
+```ruby
+gem 'multi_json'
+```
+
+If you want to use XML, add the following to your Gemfile:
+
+```ruby
+gem 'nokogiri'
+```
+
 
 ## Defining Representers
 


### PR DESCRIPTION
Visit [representable gem PR #141](https://github.com/apotonick/representable/pull/141/files#diff-04c6e90faac2675aa89e2176d2eec7d8R23) for more details.