### PR TITLE
Jsonapi work towards v1.0 spec.

### DIFF
--- a/lib/roar/json/json_api.rb
+++ b/lib/roar/json/json_api.rb
@@ -134,11 +134,12 @@ module Roar
 
       private
         def to_document(res, options)
+          data = render_data(res)
           links = render_links
           meta  = render_meta(options)
           compound = render_compound(res)
 
-          {"data" => res}.tap do |doc|
+          {"data" => data}.tap do |doc|
             doc.merge!(links)
             doc.merge!(meta)
             doc.merge!(compound)
@@ -169,6 +170,15 @@ module Roar
 
           return {} unless compound && compound.size > 0
           {"included" => compound}
+        end
+
+        def render_data(res)
+          data = {
+            "id" => res.delete("id").to_s,
+            "type" => res.delete("type"),
+          }
+          data["attributes"] = res if res && res.size > 0
+          data
         end
 
         def render_compound(res)
@@ -203,6 +213,10 @@ module Roar
           end
 
         private
+          def render_data(collection)
+            collection.map { |res| super(res) }
+          end
+
           def render_compound(res)
             collection_compound!(res, {})
           end

--- a/test/json_api_test.rb
+++ b/test/json_api_test.rb
@@ -51,11 +51,8 @@ if Gem::Version.new(Representable::VERSION) >= Gem::Version.new("2.1.4") # TODO:
       property :id
       property :title, if: lambda { |args| args[:omit_title] != true }
 
-      # local per-model "id" links
-      links do
-        property :album_id, :as => :album
-        collection :musician_ids, :as => :musicians
-      end
+      has_one :album
+      has_many :musicians
       has_one :composer
       has_many :listeners
 
@@ -80,11 +77,8 @@ if Gem::Version.new(Representable::VERSION) >= Gem::Version.new("2.1.4") # TODO:
       # NOTE: it is important to call has_one, then links, then has_many to assert that they all write
       #to the same _links property and do NOT override things.
       has_one :composer
-      # local per-model "id" links
-      links do
-        property :album_id, :as => :album
-        collection :musician_ids, :as => :musicians
-      end
+      has_one :album
+      has_many :musicians
       has_many :listeners
 
       compound do
@@ -397,13 +391,10 @@ if Gem::Version.new(Representable::VERSION) >= Gem::Version.new("2.1.4") # TODO:
         property :id
         property :title
 
-        # local per-model "id" links
-        links do
-          property :album_id, :as => :album
-          collection :musician_ids, :as => :musicians
-        end
+        has_many :musicians
         has_one :composer
         has_many :listeners
+        has_one :album
       end
 
       subject { [song, song].extend(Singular.for_collection) }
@@ -490,6 +481,7 @@ if Gem::Version.new(Representable::VERSION) >= Gem::Version.new("2.1.4") # TODO:
 
         type :albums
         property :id
+
         compound do
           collection :songs, extend: SongRepresenter
         end


### PR DESCRIPTION
First off, I'm still getting the hang of representable / roar's internals & your coding style, so suggestions and better / cleaner ways to do things very much appreciated :). Please consider this PR 'in progress' and a request for feedback.

Onward:

I've been working on the JSONAPI implementation, trying to get it to more accurately match the v1 spec, and I've made some progress. Specifically, basic "attributes" and "relationships" support is more or less done. I removed the "links" method, as I don't _think_ it really fits with JSONAPI any more, but correct me if I'm wrong. I wasn't entirely sure what semantics it was trying to fulfil there.

The included / compound concept still needs a lot of work... according to the spec it's supposed to be a single level array (not object) at the top level of the document, and for an object to be there it _must_ be listed as a relationship on something else (either the main document or one of it's embedded relationships) It also _must_ have a type/id pair, like everything else. With the current API expressed by the tests (just passing a block) I don't think this is really doable. I've been wondering if it wouldn't be better to handle this with an option on `has_one` and `has_many` (e.g. `has_one :album, include: true`) which would add the related objects to the 'included' array, and do away with the compound keyword altogether?