### PR TITLE
Remove redundant to_h array splat

### DIFF
--- a/lib/roar/hypermedia.rb
+++ b/lib/roar/hypermedia.rb
@@ -42,7 +42,7 @@ module Roar
     def links # this is _not_ called by rendering as we go via ::links_config.
       tuples = (@links||[]).collect { |link| [link.rel, link] }
       # tuples.to_h
-      ::Hash[[*tuples]] # TODO: tuples.to_h when dropping < 2.1.
+      ::Hash[tuples] # TODO: tuples.to_h when dropping < 2.1.
     end
 
   private

--- a/lib/roar/json/hal.rb
+++ b/lib/roar/json/hal.rb
@@ -210,7 +210,7 @@ module Roar
           end.compact
 
           # tuples.to_h
-          ::Hash[[*tuples]] # TODO: tuples.to_h when dropping < 2.1.
+          ::Hash[tuples] # TODO: tuples.to_h when dropping < 2.1.
         end
       end
     end

--- a/lib/roar/json/json_api.rb
+++ b/lib/roar/json/json_api.rb
@@ -103,7 +103,7 @@ module Roar
           def call(res, options)
             tuples = (res.delete("links") || []).collect { |link| [link["rel"], link["href"]] }
             # tuples.to_h
-            ::Hash[[*tuples]] # TODO: tuples.to_h when dropping < 2.1.
+            ::Hash[tuples] # TODO: tuples.to_h when dropping < 2.1.
           end
         end
       end


### PR DESCRIPTION
Because wrapping a splat in an array is equivalent to the original array:
```ruby
x = [1,2]
x == [*x]
=> true
```