### PR TITLE
Provide empty array as default if "relationships" attribute is not present

### DIFF
--- a/lib/roar/json/json_api.rb
+++ b/lib/roar/json/json_api.rb
@@ -193,7 +193,7 @@ module Roar
           attributes = hash["data"]["attributes"] || {}
           attributes["relationships"] = {}
 
-          hash["data"]["relationships"].each do |rel, fragment| # FIXME: what if nil?
+          hash["data"].fetch("relationships", []).each do |rel, fragment|
             attributes["relationships"][rel] = fragment["data"] # DISCUSS: we could use a relationship representer here (but only if needed elsewhere).
           end
 

--- a/test/jsonapi/post_test.rb
+++ b/test/jsonapi/post_test.rb
@@ -40,4 +40,23 @@ class JsonapiPostTest < MiniTest::Spec
       subject.comments.must_equal [Comment.new("2"), Comment.new("3")]
     end
   end
+
+  describe "Parse Simple" do
+    let(:post_article) {
+      {
+        "data" => {
+          "type" => "articles",
+          "attributes" => {
+            "title" => "Ember Hamster",
+          }
+        }
+      }
+    }
+
+    subject { ArticleDecorator.new(Article.new(nil, nil, nil, nil, [])).from_json(post_article.to_json) }
+
+    it do
+      subject.title.must_equal "Ember Hamster"
+    end
+  end
 end


### PR DESCRIPTION
The "relationships" attribute is not required when passing a document to the server.  Instead of trying to iterate on `nil`, we now try to `fetch` the "relationships" attribute, and return an empty array as a default if it is not found.