### PR TITLE
return an empty hash if the "data" attribute is not present in the document

### DIFF
--- a/lib/roar/json/json_api.rb
+++ b/lib/roar/json/json_api.rb
@@ -189,6 +189,7 @@ module Roar
 
       private
         def from_document(hash)
+          return {} unless hash["data"] # DISCUSS: Is failing silently here a good idea?
           # hash: {"data"=>{"type"=>"articles", "attributes"=>{"title"=>"Ember Hamster"}, "relationships"=>{"author"=>{"data"=>{"type"=>"people", "id"=>"9"}}}}}
           attributes = hash["data"]["attributes"] || {}
           attributes["relationships"] = {}

--- a/test/jsonapi/post_test.rb
+++ b/test/jsonapi/post_test.rb
@@ -40,4 +40,16 @@ class JsonapiPostTest < MiniTest::Spec
       subject.comments.must_equal [Comment.new("2"), Comment.new("3")]
     end
   end
+
+  describe "Parse Badly Formed Document" do
+    let(:post_article) {
+      { "title" => "Ember Hamster" }
+    }
+
+    subject { ArticleDecorator.new(Article.new(nil, nil, nil, nil, [])).from_json(post_article.to_json) }
+
+    it do
+      subject.title.must_equal nil
+    end
+  end
 end


### PR DESCRIPTION
Currently if an improperly structured document is passed in, this method will throw an exception.  This PR will effectively discard the hash if it does not contain a "data" key, which at the very least is required with JSONAPI