### PR TITLE
JSON-API: Do not render links for relationships if there are none

### DIFF
--- a/lib/roar/json/json_api.rb
+++ b/lib/roar/json/json_api.rb
@@ -228,11 +228,11 @@ module Roar
         def render_relationships(res)
           (res["relationships"] || []).each do |name, hash|
             if hash.is_a?(::Hash)
-              hash[:links] = hash[:data].delete(:links)
+              hash[:links] = hash[:data].delete(:links) if hash[:data].has_key? :links
             else # hash => [{data: {}}, ..]
               res["relationships"][name] = collection = {data: []}
               hash.each do |hsh|
-                collection[:links] = hsh[:data].delete(:links) # FIXME: this is horrible.
+                collection[:links] = hsh[:data].delete(:links) if hsh[:data].has_key? :links
                 collection[:data] << hsh[:data]
               end
             end

--- a/test/jsonapi/collection_render_test.rb
+++ b/test/jsonapi/collection_render_test.rb
@@ -22,8 +22,7 @@ class JsonapiCollectionRenderTest < MiniTest::Spec
              {:data=>{:type=>"authors", :id=>"2"},
               :links=>{"self"=>"http://authors/2"}},
             "editor"=>
-             {:data=>{:type=>"editors", :id=>"editor:1"},
-              :links=>{"self"=>"http://authors/editor:1"}},
+             {:data=>{:type=>"editors", :id=>"editor:1"}},
             "comments"=>
              {:data=>
                [{:type=>"comments",
@@ -61,8 +60,7 @@ class JsonapiCollectionRenderTest < MiniTest::Spec
        :included=>
         [{:type=>"authors", :id=>"2", :links=>{"self"=>"http://authors/2"}},
          {:type=>"editors",
-          :id=>"editor:1",
-          :links=>{"self"=>"http://authors/editor:1"}},
+          :id=>"editor:1"},
          {:type=>"comments",
           :id=>"comment:1",
           :attributes=>{"body"=>"Ice and Snow"},
@@ -97,8 +95,7 @@ class JsonapiCollectionRenderTest < MiniTest::Spec
              {:data=>{:type=>"authors", :id=>"2"},
               :links=>{"self"=>"http://authors/2"}},
             "editor"=>
-             {:data=>{:type=>"editors", :id=>"editor:1"},
-              :links=>{"self"=>"http://authors/editor:1"}},
+             {:data=>{:type=>"editors", :id=>"editor:1"}},
             "comments"=>
              {:data=>
                [{:type=>"comments",

--- a/test/jsonapi/render_test.rb
+++ b/test/jsonapi/render_test.rb
@@ -23,8 +23,7 @@ class JsonapiRenderTest < MiniTest::Spec
               {:data=>{:type=>"authors", :id=>"2"},
                :links=>{"self"=>"http://authors/2"}},
              "editor"=>
-              {:data=>{:type=>"editors", :id=>"editor:1"},
-               :links=>{"self"=>"http://authors/editor:1"}},
+              {:data=>{:type=>"editors", :id=>"editor:1"}},
              "comments"=>
               {:data=>
                 [
@@ -51,8 +50,7 @@ class JsonapiRenderTest < MiniTest::Spec
           },
           {
             :type=>"editors",
-            :id=>"editor:1",
-            :links=>{"self"=>"http://authors/editor:1"}
+            :id=>"editor:1"
           },
           {
             :type=>"comments",
@@ -84,8 +82,7 @@ class JsonapiRenderTest < MiniTest::Spec
                 {:data=>{:type=>"authors", :id=>"2"},
                  :links=>{"self"=>"http://authors/2"}},
                "editor"=>
-                {:data=>{:type=>"editors", :id=>"editor:1"},
-                 :links=>{"self"=>"http://authors/editor:1"}},
+                {:data=>{:type=>"editors", :id=>"editor:1"}},
                "comments"=>
                 {:data=>
                   [

--- a/test/jsonapi/representer.rb
+++ b/test/jsonapi/representer.rb
@@ -44,7 +44,7 @@ class ArticleDecorator < Roar::Decorator
 
     property :id
     property :email
-    link(:self) { "http://authors/#{represented.id}" }
+    # No self link for editors because we want to make sure the :links option does not appear in the hash.
   end
 
   has_many :comments, class: Comment, populator: ::Representable::FindOrInstantiate do


### PR DESCRIPTION
Fixes part of #177.