### PR TITLE
added a test for JSON-HAL's embedded single resource

### DIFF
--- a/test/hal_json_test.rb
+++ b/test/hal_json_test.rb
@@ -97,6 +97,16 @@ class HalJsonTest < MiniTest::Spec
       assert_equal "http://albums/2", album.links["self"].href
     end
 
+    describe "with a single Resource instead of an Array of Resources" do
+      it "parses links and resources following the mighty HAL" do
+        album.from_json("{\"id\":2,\"_embedded\":{\"songs\":{\"title\":\"Coffee\",\"_links\":{\"self\":{\"href\":\"http://songs/Coffee\"}}}},\"_links\":{\"self\":{\"href\":\"http://albums/2\"}}}")
+        assert_equal 2, album.id
+        assert_equal "Coffee", album.songs.first.title
+        assert_equal "http://songs/Coffee", album.songs.first.links["self"].href
+        assert_equal "http://albums/2", album.links["self"].href
+      end
+    end
+
     it "doesn't require _links and _embedded to be present" do
       album.from_json("{\"id\":2}")
       assert_equal 2, album.id


### PR DESCRIPTION
This one will add a test if the data under a JSON-HAL's _embedded property is a single resource, and not an array of resources. It requires the pull request apotonick/representable#189 to be merged into representable.