### PR TITLE
support options for top-level link blocks

### DIFF
--- a/lib/roar/json/json_api.rb
+++ b/lib/roar/json/json_api.rb
@@ -32,7 +32,7 @@ module Roar
             # link(:self) { .. }
 
             def to_hash(options={})
-              hash = super(to_a: options) # [{data: {..}, data: {..}}]
+              hash = super(to_a: options, user_options: options[:user_options]) # [{data: {..}, data: {..}}]
               collection = hash["to_a"]
 
               document = {data: []}

--- a/test/jsonapi/collection_render_test.rb
+++ b/test/jsonapi/collection_render_test.rb
@@ -135,6 +135,13 @@ class JsonapiCollectionRenderTest < MiniTest::Spec
     )
   end
 
+  it "passes :user_options to toplevel links when rendering" do
+    hash = decorator.to_hash(user_options: { page: 2, per_page: 10 })
+    hash[:links].must_equal({
+      "self" => "//articles?page=2&per_page=10"
+    })
+  end
+
   describe "Fetching Resources (empty collection)" do
     let(:document) {
       {

--- a/test/jsonapi/representer.rb
+++ b/test/jsonapi/representer.rb
@@ -18,8 +18,12 @@ class ArticleDecorator < Roar::Decorator
   type :articles
 
   # top-level link.
-  link :self, toplevel: true do
-    "//articles"
+  link :self, toplevel: true do |options|
+    if options
+      "//articles?page=#{options[:page]}&per_page=#{options[:per_page]}"
+    else
+      "//articles"
+    end
   end
 
   # attributes: {}


### PR DESCRIPTION
For example:
```
link toplevel: true) do |options|
  "/articles?#{options[:page]}"
end
```