### PR TITLE
Set minimum Ruby version to 2.2

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -25,7 +25,7 @@ If in need for a feature, make sure to check the [representable API docs](https:
 
 ## Installation
 
-The roar gem runs with all Ruby versions >= 1.9.3.
+The roar gem runs with all Ruby versions >= 2.2.
 
 ```ruby
 gem 'roar'

--- a/roar.gemspec
+++ b/roar.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
+  s.required_ruby_version = '>= 2.2.0'
+
   s.add_runtime_dependency "representable", "~> 3.0.0"
 
   s.add_development_dependency "rake", ">= 0.10.1"


### PR DESCRIPTION
**Rationale:**

This matches the versions of Ruby we are now testing against (2.2+). (87b00668233b5382b3736f62a1ea491353d43903)
Sinatra 2.0, which we use for tests, [requires Ruby 2.2+](https://github.com/sinatra/sinatra/commit/f62011c528a68e09a07f379607bd500a314977d5)

Representable, however, still allows Ruby 1.9.3, 2.0: https://github.com/apotonick/representable/blob/master/representable.gemspec#L22